### PR TITLE
Adding XLA translation rules for JAX extension

### DIFF
--- a/docs/tutorials/first.py
+++ b/docs/tutorials/first.py
@@ -182,7 +182,6 @@ plot_prediction(opt_gp)
 
 # +
 import emcee
-from multiprocessing import Pool
 
 prior_sigma = 2.0
 

--- a/docs/tutorials/first.py
+++ b/docs/tutorials/first.py
@@ -182,12 +182,15 @@ plot_prediction(opt_gp)
 
 # +
 import emcee
+from multiprocessing import Pool
+
+prior_sigma = 2.0
 
 
 def log_prob(params, gp):
     gp = set_params(params, gp)
     return (
-        gp.log_likelihood(y) - 0.5 * np.sum((params / 5.0) ** 2),
+        gp.log_likelihood(y) - 0.5 * np.sum((params / prior_sigma) ** 2),
         gp.kernel.get_psd(omega),
     )
 
@@ -198,6 +201,8 @@ sampler = emcee.EnsembleSampler(
     coords.shape[0], coords.shape[1], log_prob, args=(gp,)
 )
 state = sampler.run_mcmc(coords, 2000, progress=True)
+sampler.reset()
+state = sampler.run_mcmc(state, 5000, progress=True)
 # -
 
 # After running our MCMC, we can plot the predictions that the model makes for a handful of samples from the chain.
@@ -242,16 +247,16 @@ from celerite2.theano import terms as theano_terms
 
 with pm.Model() as model:
 
-    mean = pm.Normal("mean", mu=0.0, sigma=5.0)
-    jitter = pm.Lognormal("jitter", mu=0.0, sigma=5.0)
+    mean = pm.Normal("mean", mu=0.0, sigma=prior_sigma)
+    jitter = pm.Lognormal("jitter", mu=0.0, sigma=prior_sigma)
 
-    sigma1 = pm.Lognormal("sigma1", mu=0.0, sigma=5.0)
-    rho1 = pm.Lognormal("rho1", mu=0.0, sigma=5.0, testval=np.exp(soln.x[2]))
-    tau = pm.Lognormal("tau", mu=0.0, sigma=5.0)
+    sigma1 = pm.Lognormal("sigma1", mu=0.0, sigma=prior_sigma)
+    rho1 = pm.Lognormal("rho1", mu=0.0, sigma=prior_sigma)
+    tau = pm.Lognormal("tau", mu=0.0, sigma=prior_sigma)
     term1 = theano_terms.SHOTerm(sigma=sigma1, rho=rho1, tau=tau)
 
-    sigma2 = pm.Lognormal("sigma2", mu=0.0, sigma=5.0)
-    rho2 = pm.Lognormal("rho2", mu=0.0, sigma=5.0)
+    sigma2 = pm.Lognormal("sigma2", mu=0.0, sigma=prior_sigma)
+    rho2 = pm.Lognormal("rho2", mu=0.0, sigma=prior_sigma)
     term2 = theano_terms.SHOTerm(sigma=sigma2, rho=rho2, Q=0.25)
 
     kernel = term1 + term2
@@ -264,7 +269,7 @@ with pm.Model() as model:
     trace = pm.sample(
         tune=1000,
         draws=1000,
-        target_accept=0.95,
+        target_accept=0.8,
         init="adapt_full",
         cores=2,
         chains=2,
@@ -288,11 +293,10 @@ plt.ylabel("power [day ppt$^2$]")
 _ = plt.title("posterior psd using PyMC3")
 # -
 
-# In this particular case, the runtime with PyMC3 is somewhat longer than with emcee, but it also produced more effective samples.
-# If we were to run a higher dimensional model (with more parameters) then PyMC3 will generally be substantially faster.
-
 # ## Posterior inference using numpyro
 #
+# Since celerite2 includes support for JAX as well as Theano, you can also use tools like [numpyro](https://github.com/pyro-ppl/numpyro) for inference.
+# The following is similar to previous PyMC3 example, but the main difference is that (for technical reasons related to how JAX works) `SHOTerm`s cannot be used in combination with `jax.jit`, so we need to explicitly specify the terms as "underdamped" (`UnderdampedSHOTerm`) or "overdamped" (`OverdampedSHOTerm`).
 
 # +
 from jax.config import config
@@ -309,36 +313,25 @@ import celerite2.jax
 from celerite2.jax import terms as jax_terms
 
 
-class CeleriteDist(dist.Distribution):
-    support = dist.constraints.real
-
-    def __init__(self, gp, validate_args=None):
-        self.gp = gp
-        super().__init__(validate_args=validate_args)
-
-    @dist.util.validate_sample
-    def log_prob(self, value):
-        return self.gp.log_likelihood(value)
-
-
 def numpyro_model(t, yerr, y=None):
-    mean = numpyro.sample("mean", dist.Normal(0.0, 5.0))
-    jitter = numpyro.sample("jitter", dist.LogNormal(0.0, 5.0))
+    mean = numpyro.sample("mean", dist.Normal(0.0, prior_sigma))
+    jitter = numpyro.sample("jitter", dist.LogNormal(0.0, prior_sigma))
 
-    sigma1 = numpyro.sample("sigma1", dist.LogNormal(0.0, 5.0))
-    rho1 = numpyro.sample("rho1", dist.LogNormal(0.0, 5.0))
-    tau = numpyro.sample("tau", dist.LogNormal(0.0, 5.0))
+    sigma1 = numpyro.sample("sigma1", dist.LogNormal(0.0, prior_sigma))
+    rho1 = numpyro.sample("rho1", dist.LogNormal(0.0, prior_sigma))
+    tau = numpyro.sample("tau", dist.LogNormal(0.0, prior_sigma))
     term1 = jax_terms.UnderdampedSHOTerm(sigma=sigma1, rho=rho1, tau=tau)
 
-    sigma2 = numpyro.sample("sigma2", dist.LogNormal(0.0, 5.0))
-    rho2 = numpyro.sample("rho2", dist.LogNormal(0.0, 5.0))
+    sigma2 = numpyro.sample("sigma2", dist.LogNormal(0.0, prior_sigma))
+    rho2 = numpyro.sample("rho2", dist.LogNormal(0.0, prior_sigma))
     term2 = jax_terms.OverdampedSHOTerm(sigma=sigma2, rho=rho2, Q=0.25)
 
     kernel = term1 + term2
     gp = celerite2.jax.GaussianProcess(kernel, mean=mean)
     gp.compute(t, diag=yerr ** 2 + jitter, check_sorted=False)
 
-    numpyro.sample("obs", CeleriteDist(gp), obs=y)
+    numpyro.sample("obs", gp.numpyro_dist(), obs=y)
+    numpyro.deterministic("psd", kernel.get_psd(omega))
 
 
 nuts_kernel = NUTS(numpyro_model, dense_mass=True)
@@ -346,3 +339,101 @@ mcmc = MCMC(nuts_kernel, num_warmup=1000, num_samples=1000, num_chains=2)
 rng_key = random.PRNGKey(34923)
 # %time mcmc.run(rng_key, t, yerr, y=y)
 # -
+
+# This runtime was similar to the PyMC3 result from above, and (as we'll see below) the convergence is also similar.
+# Any difference in runtime will probably disappear for more computationally expensive models, but this interface is looking pretty great here!
+#
+# As above, we can plot the posterior expectations for the power spectrum:
+
+# +
+psds = np.asarray(mcmc.get_samples()["psd"])
+
+q = np.percentile(psds, [16, 50, 84], axis=0)
+
+plt.loglog(freq, q[1], color="C0")
+plt.fill_between(freq, q[0], q[2], color="C0", alpha=0.1)
+
+plt.xlim(freq.min(), freq.max())
+plt.xlabel("frequency [1 / day]")
+plt.ylabel("power [day ppt$^2$]")
+_ = plt.title("posterior psd using numpyro")
+# -
+
+# ## Comparison
+#
+# Finally, let's compare the results of these different inference methods a bit more quantitaively.
+# First, let's look at the posterior constraint on the period of the underdamped harmonic oscillator, the effective period of the oscillatory signal.
+
+# +
+import arviz as az
+
+emcee_data = az.from_emcee(
+    sampler,
+    var_names=[
+        "mean",
+        "log_sigma1",
+        "log_rho1",
+        "log_tau",
+        "log_sigma2",
+        "log_rho2",
+        "log_jitter",
+    ],
+)
+for k in emcee_data.posterior.data_vars:
+    if k.startswith("log_"):
+        emcee_data.posterior[k[4:]] = np.exp(emcee_data.posterior[k])
+
+with model:
+    pm_data = az.from_pymc3(trace)
+
+numpyro_data = az.from_numpyro(mcmc)
+
+bins = np.linspace(1.5, 2.75, 25)
+plt.hist(
+    np.asarray((emcee_data.posterior["rho1"].T)).flatten(),
+    bins,
+    histtype="step",
+    density=True,
+    label="emcee",
+)
+plt.hist(
+    np.asarray((pm_data.posterior["rho1"].T)).flatten(),
+    bins,
+    histtype="step",
+    density=True,
+    label="PyMC3",
+)
+plt.hist(
+    np.asarray((numpyro_data.posterior["rho1"].T)).flatten(),
+    bins,
+    histtype="step",
+    density=True,
+    label="numpyro",
+)
+plt.legend()
+plt.yticks([])
+plt.xlabel(r"$\rho_1$")
+_ = plt.ylabel(r"$p(\rho_1)$")
+# -
+
+# That looks pretty consistent.
+#
+# Next we can look at the [ArviZ](https://arviz-devs.github.io/arviz/) summary for each method to see how the posterior expectations and convergence diagnostics look.
+
+az.summary(
+    emcee_data,
+    var_names=["mean", "sigma1", "rho1", "tau", "sigma2", "rho2", "jitter"],
+)
+
+az.summary(
+    pm_data,
+    var_names=["mean", "sigma1", "rho1", "tau", "sigma2", "rho2", "jitter"],
+)
+
+az.summary(
+    numpyro_data,
+    var_names=["mean", "sigma1", "rho1", "tau", "sigma2", "rho2", "jitter"],
+)
+
+# Overall these results are consistent, but the $\hat{R}$ values are a bit high for the emcee run, so I'd probably run that for longer.
+# Either way, for models like these, PyMC3 and numpyro are generally going to be much better inference tools (in terms of runtime per effective sample) than emcee, so those are the recommended interfaces if the rest of your model can be easily implemented in such a framework.

--- a/python/celerite2/backprop.cpp
+++ b/python/celerite2/backprop.cpp
@@ -103,8 +103,8 @@ auto solve_fwd(py::array_t<double, py::array::c_style> U, py::array_t<double, py
       CONST_MATRIX(Eigen::Dynamic, Y_, Ybuf, N, nrhs);                                                                                               \
       MATRIX(Eigen::Dynamic, X_, Xbuf, N, nrhs);                                                                                                     \
       MATRIX(Eigen::Dynamic, Z_, Zbuf, N, nrhs);                                                                                                     \
-      MATRIX(Eigen::Dynamic, F_, Fbuf, N, J *nrhs);                                                                                                  \
-      MATRIX(Eigen::Dynamic, G_, Gbuf, N, J *nrhs);                                                                                                  \
+      MATRIX(Eigen::Dynamic, F_, Fbuf, N, (J * nrhs));                                                                                               \
+      MATRIX(Eigen::Dynamic, G_, Gbuf, N, (J * nrhs));                                                                                               \
       celerite2::core::solve(U_, P_, d_, W_, Y_, X_, Z_, F_, G_);                                                                                    \
     }                                                                                                                                                \
   }
@@ -162,8 +162,8 @@ auto solve_rev(py::array_t<double, py::array::c_style> U, py::array_t<double, py
       CONST_MATRIX(Eigen::Dynamic, Y_, Ybuf, N, nrhs);                                                                                               \
       CONST_MATRIX(Eigen::Dynamic, X_, Xbuf, N, nrhs);                                                                                               \
       CONST_MATRIX(Eigen::Dynamic, Z_, Zbuf, N, nrhs);                                                                                               \
-      CONST_MATRIX(Eigen::Dynamic, F_, Fbuf, N, J *nrhs);                                                                                            \
-      CONST_MATRIX(Eigen::Dynamic, G_, Gbuf, N, J *nrhs);                                                                                            \
+      CONST_MATRIX(Eigen::Dynamic, F_, Fbuf, N, (J * nrhs));                                                                                         \
+      CONST_MATRIX(Eigen::Dynamic, G_, Gbuf, N, (J * nrhs));                                                                                         \
                                                                                                                                                      \
       CONST_MATRIX(Eigen::Dynamic, bX_, bXbuf, N, nrhs);                                                                                             \
       MATRIX(Eigen::Dynamic, bY_, bYbuf, N, nrhs);                                                                                                   \
@@ -200,7 +200,7 @@ auto dot_tril_fwd(py::array_t<double, py::array::c_style> U, py::array_t<double,
     } else {                                                                                                                                         \
       CONST_MATRIX(Eigen::Dynamic, Y_, Ybuf, N, nrhs);                                                                                               \
       MATRIX(Eigen::Dynamic, Z_, Zbuf, N, nrhs);                                                                                                     \
-      MATRIX(Eigen::Dynamic, F_, Fbuf, N, J *nrhs);                                                                                                  \
+      MATRIX(Eigen::Dynamic, F_, Fbuf, N, (J * nrhs));                                                                                               \
       celerite2::core::dot_tril(U_, P_, d_, W_, Y_, Z_, F_);                                                                                         \
     }                                                                                                                                                \
   }
@@ -370,8 +370,8 @@ auto matmul_fwd(py::array_t<double, py::array::c_style> d, py::array_t<double, p
       CONST_MATRIX(Eigen::Dynamic, Y_, Ybuf, N, nrhs);                                                                                               \
       MATRIX(Eigen::Dynamic, X_, Xbuf, N, nrhs);                                                                                                     \
       MATRIX(Eigen::Dynamic, Z_, Zbuf, N, nrhs);                                                                                                     \
-      MATRIX(Eigen::Dynamic, F_, Fbuf, N, J *nrhs);                                                                                                  \
-      MATRIX(Eigen::Dynamic, G_, Gbuf, N, J *nrhs);                                                                                                  \
+      MATRIX(Eigen::Dynamic, F_, Fbuf, N, (J * nrhs));                                                                                               \
+      MATRIX(Eigen::Dynamic, G_, Gbuf, N, (J * nrhs));                                                                                               \
       celerite2::core::matmul(d_, U_, W_, P_, Y_, X_, Z_, F_, G_);                                                                                   \
     }                                                                                                                                                \
   }
@@ -429,8 +429,8 @@ auto matmul_rev(py::array_t<double, py::array::c_style> d, py::array_t<double, p
       CONST_MATRIX(Eigen::Dynamic, Y_, Ybuf, N, nrhs);                                                                                               \
       CONST_MATRIX(Eigen::Dynamic, X_, Xbuf, N, nrhs);                                                                                               \
       CONST_MATRIX(Eigen::Dynamic, Z_, Zbuf, N, nrhs);                                                                                               \
-      CONST_MATRIX(Eigen::Dynamic, F_, Fbuf, N, J *nrhs);                                                                                            \
-      CONST_MATRIX(Eigen::Dynamic, G_, Gbuf, N, J *nrhs);                                                                                            \
+      CONST_MATRIX(Eigen::Dynamic, F_, Fbuf, N, (J * nrhs));                                                                                         \
+      CONST_MATRIX(Eigen::Dynamic, G_, Gbuf, N, (J * nrhs));                                                                                         \
                                                                                                                                                      \
       CONST_MATRIX(Eigen::Dynamic, bX_, bXbuf, N, nrhs);                                                                                             \
       MATRIX(Eigen::Dynamic, bY_, bYbuf, N, nrhs);                                                                                                   \

--- a/python/celerite2/jax/__init__.py
+++ b/python/celerite2/jax/__init__.py
@@ -15,7 +15,8 @@ if not config.read("jax_enable_x64"):
     )
 
 
-__all__ = ["terms", "GaussianProcess"]
+__all__ = ["terms", "GaussianProcess", "CeleriteNormal"]
 
 from . import terms  # noqa isort:skip
 from .celerite2 import GaussianProcess  # noqa isort:skip
+from .distribution import CeleriteNormal

--- a/python/celerite2/jax/__init__.py
+++ b/python/celerite2/jax/__init__.py
@@ -1,6 +1,21 @@
 # -*- coding: utf-8 -*-
 
+import logging
+
+logger = logging.getLogger(__name__)
+
+from jax.config import config  # noqa isort:skip
+
+if not config.read("jax_enable_x64"):
+    logger.warning(
+        "celerite2.jax only works with dtype float64. "
+        "To enable, run (before importing jax or celerite2.jax):\n"
+        ">>> from jax.config import config\n"
+        ">>> config.update('jax_enable_x64', True)"
+    )
+
+
 __all__ = ["terms", "GaussianProcess"]
 
-from . import terms
-from .celerite2 import GaussianProcess
+from . import terms  # noqa isort:skip
+from .celerite2 import GaussianProcess  # noqa isort:skip

--- a/python/celerite2/jax/celerite2.py
+++ b/python/celerite2/jax/celerite2.py
@@ -5,7 +5,7 @@ from jax import numpy as np
 
 from .. import backprop, driver
 from ..ext import BaseGaussianProcess
-from . import ops
+from . import distribution, ops
 
 
 class GaussianProcess(BaseGaussianProcess):
@@ -52,3 +52,6 @@ class GaussianProcess(BaseGaussianProcess):
 
     def diagdot(self, a, b):
         return np.einsum("ij,ij->j", a, b)
+
+    def numpyro_dist(self):
+        return distribution.CeleriteNormal(self)

--- a/python/celerite2/jax/celerite2.py
+++ b/python/celerite2/jax/celerite2.py
@@ -33,8 +33,6 @@ class GaussianProcess(BaseGaussianProcess):
             )
 
     def check_sorted(self, t):
-        if np.any(np.diff(t) < 0.0):
-            raise ValueError("the input coordinates must be sorted")
         return t
 
     def do_solve(self, y):

--- a/python/celerite2/jax/distribution.py
+++ b/python/celerite2/jax/distribution.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+__all__ = ["CeleriteNormal"]
+from jax import numpy as jnp
+from jax import random as random
+
+try:
+    import numpyro  # noqa
+except ImportError:
+
+    class CeleriteNormal:
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "pymc3 is required to use the CeleriteNormal distribution"
+            )
+
+
+else:
+    from numpyro import distributions as dist
+
+    class CeleriteNormal(dist.Distribution):
+        support = dist.constraints.real_vector
+
+        def __init__(self, gp, validate_args=None):
+            self.gp = gp
+            super().__init__(
+                batch_shape=(),
+                event_shape=jnp.shape(self.gp._t),
+                validate_args=validate_args,
+            )
+
+        @dist.util.validate_sample
+        def log_prob(self, value):
+            return self.gp.log_likelihood(value)
+
+        def sample(self, key, sample_shape=()):
+            eps = random.normal(key, shape=self.event_shape + sample_shape)
+            return jnp.moveaxis(self.gp.dot_tril(eps), 0, -1)

--- a/python/celerite2/jax/ops.py
+++ b/python/celerite2/jax/ops.py
@@ -66,7 +66,8 @@ def matmul(a, U, V, P, Y):
 
 
 def conditional_mean(U, V, P, z, U_star, V_star, inds):
-    return conditional_mean_prim.bind(U, V, P, z, U_star, V_star, inds)
+    (mu,) = conditional_mean_prim.bind(U, V, P, z, U_star, V_star, inds)
+    return mu
 
 
 def _abstract_eval(spec, *args):

--- a/python/celerite2/jax/ops.py
+++ b/python/celerite2/jax/ops.py
@@ -16,27 +16,146 @@ __all__ = [
     "matmul",
     "conditional_mean",
 ]
-import logging
 from functools import wraps
 
+import jax
 import numpy as np
+from jax import core
+from jax import numpy as jnp
+from jax.abstract_arrays import ShapedArray
+from jax.interpreters import xla
+from jax.lax import _broadcasting_select
+from jax.lib import xla_client
 
 from .. import driver, ext
+from . import xla_ops
 
-logger = logging.getLogger(__name__)
+xops = xla_client.ops
 
-from jax.config import config  # noqa isort:skip
+xla_client.register_cpu_custom_call_target(
+    b"celerite2_factor", xla_ops.factor(), platform="cpu"
+)
 
-if not config.read("jax_enable_x64"):
-    logger.warning(
-        "celerite2.jax only works with dtype float64. "
-        "To enable, run (before importing jax or celerite2.jax):\n"
-        ">>> from jax.config import config\n"
-        ">>> config.update('jax_enable_x64', True)"
+
+def factor(a, U, V, P):
+    return factor_p.bind(a, U, V, P)
+
+
+def factor_impl(a, U, V, P):
+    return xla.apply_primitive(factor_p, a, U, V, P)
+
+
+def factor_abstract_eval(a, U, V, P):
+    N, J = U.shape
+    if a.shape != (N,):
+        raise ValueError(
+            f"Invalid shape for 'a'; expected {(N,)}, got {a.shape}"
+        )
+    if V.shape != (N, J):
+        raise ValueError(
+            f"Invalid shape for 'V'; expected {(N, J)}, got {V.shape}"
+        )
+    if P.shape != (N - 1, J):
+        raise ValueError(
+            f"Invalid shape for 'P'; expected {(N - 1, J)}, got {P.shape}"
+        )
+    if (
+        a.dtype != jnp.float64
+        or U.dtype != jnp.float64
+        or V.dtype != jnp.float64
+        or P.dtype != jnp.float64
+    ):
+        raise ValueError("Invalid dtype; must be float64")
+    return [
+        ShapedArray((), jnp.int32),
+        ShapedArray(a.shape, jnp.float64),
+        ShapedArray(V.shape, jnp.float64),
+        ShapedArray((N, J, J), jnp.float64),
+    ]
+
+
+def _nan_like(c, operand):
+    shape = c.get_shape(operand)
+    dtype = shape.element_type()
+    nan = xops.ConstantLiteral(c, np.array(np.nan, dtype=dtype))
+    return xops.Broadcast(nan, shape.dimensions())
+
+
+def factor_translation_rule(c, a, U, V, P):
+    shape = c.get_shape(U)
+
+    N, J = shape.dimensions()
+    dtype = shape.element_type()
+    if dtype != np.float64:
+        raise ValueError("Invalid dtype; must be float64")
+
+    flag, d, W, S = xops.CustomCallWithLayout(
+        c,
+        b"celerite2_factor",
+        operands=(
+            xops.ConstantLiteral(c, np.int32(N)),
+            xops.ConstantLiteral(c, np.int32(J)),
+            a,
+            U,
+            V,
+            P,
+        ),
+        shape_with_layout=xla_client.Shape.tuple_shape(
+            (
+                xla_client.Shape.array_shape(
+                    jnp.dtype(jnp.int32),
+                    (),
+                    (),
+                ),
+                xla_client.Shape.array_shape(
+                    jnp.dtype(jnp.float64),
+                    (N,),
+                    (0,),
+                ),
+                xla_client.Shape.array_shape(
+                    jnp.dtype(jnp.float64),
+                    (N, J),
+                    (1, 0),
+                ),
+                xla_client.Shape.array_shape(
+                    jnp.dtype(jnp.float64),
+                    (N, J, J),
+                    (
+                        2,
+                        1,
+                        0,
+                    ),
+                ),
+            )
+        ),
+        operand_shapes_with_layout=(
+            xla_client.Shape.array_shape(jnp.dtype(jnp.int32), (), ()),
+            xla_client.Shape.array_shape(jnp.dtype(jnp.int32), (), ()),
+            xla_client.Shape.array_shape(jnp.dtype(jnp.float64), (N,), (0,)),
+            xla_client.Shape.array_shape(
+                jnp.dtype(jnp.float64), (N, J), (1, 0)
+            ),
+            xla_client.Shape.array_shape(
+                jnp.dtype(jnp.float64), (N, J), (1, 0)
+            ),
+            xla_client.Shape.array_shape(
+                jnp.dtype(jnp.float64), (N - 1, J), (1, 0)
+            ),
+        ),
     )
 
-import jax  # noqa isort:skip
-import jax.numpy as jnp  # noqa isort:skip
+    # Deal with failed solves
+    ok = xops.Eq(flag, xops.ConstantLiteral(c, np.array(0, np.int32)))
+    d = _broadcasting_select(c, xops.Reshape(ok, (1,)), d, _nan_like(c, d))
+
+    return d, W, S
+
+
+factor_p = core.Primitive("celerite2_factor")
+factor_p.multiple_results = True
+factor_p.def_impl(factor_impl)
+factor_p.def_abstract_eval(factor_abstract_eval)
+xla.backend_specific_translations["cpu"][factor_p] = factor_translation_rule
 
 
 def to_jax(x):
@@ -120,13 +239,13 @@ class wrap_rev:
         return wrapped
 
 
-@jax.custom_vjp
-@wrap_impl(2)
-def factor(a, U, V, P):
-    return driver.factor(U, P, np.copy(a), np.copy(V))
+# @jax.custom_vjp
+# @wrap_impl(2)
+# def factor(a, U, V, P):
+#     return driver.factor(U, P, np.copy(a), np.copy(V))
 
 
-factor.defvjp(wrap_fwd(2)(ext.factor_fwd), wrap_rev(2)(ext.factor_rev))
+# factor.defvjp(wrap_fwd(2)(ext.factor_fwd), wrap_rev(2)(ext.factor_rev))
 
 
 @jax.custom_vjp

--- a/python/celerite2/jax/ops.py
+++ b/python/celerite2/jax/ops.py
@@ -32,10 +32,10 @@ from . import xla_ops
 xops = xla_client.ops
 
 xla_client.register_cpu_custom_call_target(
-    b"celerite2_factor", xla_ops.factor(), platform="cpu"
+    b"celerite2_factor", xla_ops.factor()
 )
 xla_client.register_cpu_custom_call_target(
-    b"celerite2_factor_rev", xla_ops.factor_rev(), platform="cpu"
+    b"celerite2_factor_rev", xla_ops.factor_rev()
 )
 
 

--- a/python/celerite2/jax/terms.py
+++ b/python/celerite2/jax/terms.py
@@ -9,12 +9,13 @@ __all__ = [
     "RealTerm",
     "ComplexTerm",
     "SHOTerm",
+    "OverdampedSHOTerm",
+    "UnderdampedSHOTerm",
     "Matern32Term",
     "RotationTerm",
 ]
 from itertools import chain, product
 
-from jax import lax
 from jax import numpy as np
 
 from .. import terms as base_terms

--- a/python/celerite2/jax/xla_ops.cpp
+++ b/python/celerite2/jax/xla_ops.cpp
@@ -30,12 +30,55 @@ const void factor(void *out_tuple, const void **in) {
   Eigen::Map<Matrix> W(W_out, N, J);
   Eigen::Map<Matrix> S(S_out, N, J * J);
 
-  celerite2::core::factor(a, U, V, P, d, W, S);
+  *flag = static_cast<int>(celerite2::core::factor(a, U, V, P, d, W, S));
+}
+
+const void factor_rev(void *out_tuple, const void **in) {
+  typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> Matrix;
+
+  void **out     = reinterpret_cast<void **>(out_tuple);
+  double *ba_out = reinterpret_cast<double *>(out[0]);
+  double *bU_out = reinterpret_cast<double *>(out[1]);
+  double *bV_out = reinterpret_cast<double *>(out[2]);
+  double *bP_out = reinterpret_cast<double *>(out[3]);
+
+  const int N         = *reinterpret_cast<const int *>(in[0]);
+  const int J         = *reinterpret_cast<const int *>(in[1]);
+  const double *a_in  = reinterpret_cast<const double *>(in[2]);
+  const double *U_in  = reinterpret_cast<const double *>(in[3]);
+  const double *V_in  = reinterpret_cast<const double *>(in[4]);
+  const double *P_in  = reinterpret_cast<const double *>(in[5]);
+  const double *d_in  = reinterpret_cast<const double *>(in[6]);
+  const double *W_in  = reinterpret_cast<const double *>(in[7]);
+  const double *S_in  = reinterpret_cast<const double *>(in[8]);
+  const double *bd_in = reinterpret_cast<const double *>(in[9]);
+  const double *bW_in = reinterpret_cast<const double *>(in[10]);
+
+  Eigen::Map<const Eigen::VectorXd> a(a_in, N);
+  Eigen::Map<const Matrix> U(U_in, N, J);
+  Eigen::Map<const Matrix> V(V_in, N, J);
+  Eigen::Map<const Matrix> P(P_in, N - 1, J);
+  Eigen::Map<const Eigen::VectorXd> d(d_in, N);
+  Eigen::Map<const Matrix> W(W_in, N, J);
+  Eigen::Map<const Matrix> S(S_in, N, J * J);
+  Eigen::Map<const Eigen::VectorXd> bd(bd_in, N);
+  Eigen::Map<const Matrix> bW(bW_in, N, J);
+
+  Eigen::Map<Eigen::VectorXd> ba(ba_out, N);
+  Eigen::Map<Matrix> bU(bU_out, N, J);
+  Eigen::Map<Matrix> bV(bV_out, N, J);
+  Eigen::Map<Matrix> bP(bP_out, N - 1, J);
+
+  celerite2::core::factor_rev(a, U, V, P, d, W, S, bd, bW, ba, bU, bV, bP);
 }
 
 PYBIND11_MODULE(xla_ops, m) {
   m.def("factor", []() {
     const char *name = "xla._CUSTOM_CALL_TARGET";
     return py::capsule((void *)&factor, name);
+  });
+  m.def("factor_rev", []() {
+    const char *name = "xla._CUSTOM_CALL_TARGET";
+    return py::capsule((void *)&factor_rev, name);
   });
 }

--- a/python/celerite2/jax/xla_ops.cpp
+++ b/python/celerite2/jax/xla_ops.cpp
@@ -10,10 +10,9 @@ const void factor(void *out_tuple, const void **in) {
   typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> Matrix;
 
   void **out    = reinterpret_cast<void **>(out_tuple);
-  int *flag     = reinterpret_cast<int *>(out[0]);
-  double *d_out = reinterpret_cast<double *>(out[1]);
-  double *W_out = reinterpret_cast<double *>(out[2]);
-  double *S_out = reinterpret_cast<double *>(out[3]);
+  double *d_out = reinterpret_cast<double *>(out[0]);
+  double *W_out = reinterpret_cast<double *>(out[1]);
+  double *S_out = reinterpret_cast<double *>(out[2]);
 
   const int N        = *reinterpret_cast<const int *>(in[0]);
   const int J        = *reinterpret_cast<const int *>(in[1]);
@@ -30,7 +29,8 @@ const void factor(void *out_tuple, const void **in) {
   Eigen::Map<Matrix> W(W_out, N, J);
   Eigen::Map<Matrix> S(S_out, N, J * J);
 
-  *flag = static_cast<int>(celerite2::core::factor(a, U, V, P, d, W, S));
+  Eigen::Index flag = celerite2::core::factor(a, U, V, P, d, W, S);
+  if (flag) d.setZero();
 }
 
 const void factor_rev(void *out_tuple, const void **in) {

--- a/python/celerite2/jax/xla_ops.cpp
+++ b/python/celerite2/jax/xla_ops.cpp
@@ -1,0 +1,41 @@
+#include <pybind11/pybind11.h>
+#include <Eigen/Core>
+#include <celerite2/celerite2.h>
+
+#include <iostream>
+
+namespace py = pybind11;
+
+const void factor(void *out_tuple, const void **in) {
+  typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> Matrix;
+
+  void **out    = reinterpret_cast<void **>(out_tuple);
+  int *flag     = reinterpret_cast<int *>(out[0]);
+  double *d_out = reinterpret_cast<double *>(out[1]);
+  double *W_out = reinterpret_cast<double *>(out[2]);
+  double *S_out = reinterpret_cast<double *>(out[3]);
+
+  const int N        = *reinterpret_cast<const int *>(in[0]);
+  const int J        = *reinterpret_cast<const int *>(in[1]);
+  const double *a_in = reinterpret_cast<const double *>(in[2]);
+  const double *U_in = reinterpret_cast<const double *>(in[3]);
+  const double *V_in = reinterpret_cast<const double *>(in[4]);
+  const double *P_in = reinterpret_cast<const double *>(in[5]);
+
+  Eigen::Map<const Eigen::VectorXd> a(a_in, N);
+  Eigen::Map<const Matrix> U(U_in, N, J);
+  Eigen::Map<const Matrix> V(V_in, N, J);
+  Eigen::Map<const Matrix> P(P_in, N - 1, J);
+  Eigen::Map<Eigen::VectorXd> d(d_out, N);
+  Eigen::Map<Matrix> W(W_out, N, J);
+  Eigen::Map<Matrix> S(S_out, N, J * J);
+
+  celerite2::core::factor(a, U, V, P, d, W, S);
+}
+
+PYBIND11_MODULE(xla_ops, m) {
+  m.def("factor", []() {
+    const char *name = "xla._CUSTOM_CALL_TARGET";
+    return py::capsule((void *)&factor, name);
+  });
+}

--- a/python/test/jax/test_celerite2.py
+++ b/python/test/jax/test_celerite2.py
@@ -15,6 +15,8 @@ else:
 
     config.update("jax_enable_x64", True)
 
+    from jax import jit
+
     from celerite2.jax import GaussianProcess, terms
 
 
@@ -70,10 +72,6 @@ def test_errors():
     # Need to call compute first
     with pytest.raises(RuntimeError):
         gp.log_likelihood(y)
-
-    # Sorted
-    with pytest.raises(ValueError):
-        gp.compute(np.copy(x[::-1]), diag=diag)
 
     # 1D
     with pytest.raises(ValueError):

--- a/python/test/jax/test_celerite2.py
+++ b/python/test/jax/test_celerite2.py
@@ -84,11 +84,7 @@ def test_errors():
         gp.compute(x, diag=diag, yerr=np.sqrt(diag))
 
     # Not positive definite
-    with pytest.raises(celerite2.backprop.LinAlgError):
-        gp.compute(x, diag=-10 * diag)
-
-    # Not positive definite with `quiet`
-    gp.compute(x, diag=-10 * diag, quiet=True)
+    gp.compute(x, diag=-10 * diag)
     ld = gp._log_det
     assert np.isinf(ld)
     assert ld < 0

--- a/python/test/jax/test_celerite2.py
+++ b/python/test/jax/test_celerite2.py
@@ -15,8 +15,6 @@ else:
 
     config.update("jax_enable_x64", True)
 
-    from jax import jit
-
     from celerite2.jax import GaussianProcess, terms
 
 

--- a/python/test/jax/test_ops.py
+++ b/python/test/jax/test_ops.py
@@ -14,6 +14,7 @@ else:
 
     config.update("jax_enable_x64", True)
 
+    from jax import jit
     from jax.test_util import check_grads
 
     from celerite2.jax import ops
@@ -38,6 +39,7 @@ def test_factor():
     a, U, V, P, Y = get_matrices()
     d, W = driver.factor(U, P, np.copy(a), np.copy(V))
     check_op(ops.factor, [a, U, V, P], [d, W])
+    check_op(jit(ops.factor), [a, U, V, P], [d, W])
 
 
 @pytest.mark.parametrize("vector", [True, False])

--- a/python/test/jax/test_ops.py
+++ b/python/test/jax/test_ops.py
@@ -48,6 +48,7 @@ def test_solve(vector):
     d, W = driver.factor(U, P, a, V)
     X = driver.solve(U, P, d, W, np.copy(Y))
     check_op(ops.solve, [U, P, d, W, Y], [X])
+    check_op(jit(ops.solve), [U, P, d, W, Y], [X])
 
 
 def test_norm():

--- a/python/test/jax/test_ops.py
+++ b/python/test/jax/test_ops.py
@@ -93,3 +93,9 @@ def test_conditional_mean():
         [mu],
         grad=False,
     )
+    check_op(
+        jit(ops.conditional_mean),
+        [U, V, P, z, U_star, V_star, inds],
+        [mu],
+        grad=False,
+    )

--- a/python/test/jax/test_ops.py
+++ b/python/test/jax/test_ops.py
@@ -56,6 +56,7 @@ def test_norm():
     d, W = driver.factor(U, P, a, V)
     X = driver.norm(U, P, d, W, np.copy(Y))
     check_op(ops.norm, [U, P, d, W, Y], [X])
+    check_op(jit(ops.norm), [U, P, d, W, Y], [X])
 
 
 @pytest.mark.parametrize("vector", [True, False])

--- a/python/test/jax/test_ops.py
+++ b/python/test/jax/test_ops.py
@@ -73,6 +73,7 @@ def test_matmul(vector):
     a, U, V, P, Y = get_matrices(vector=vector)
     X = driver.matmul(a, U, V, P, Y, np.copy(Y))
     check_op(ops.matmul, [a, U, V, P, Y], [X])
+    check_op(jit(ops.matmul), [a, U, V, P, Y], [X])
 
 
 def test_conditional_mean():

--- a/python/test/jax/test_ops.py
+++ b/python/test/jax/test_ops.py
@@ -65,6 +65,7 @@ def test_dot_tril(vector):
     d, W = driver.factor(U, P, a, V)
     X = driver.dot_tril(U, P, d, W, np.copy(Y))
     check_op(ops.dot_tril, [U, P, d, W, Y], [X])
+    check_op(jit(ops.dot_tril), [U, P, d, W, Y], [X])
 
 
 @pytest.mark.parametrize("vector", [True, False])

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ EXTRA_REQUIRE = {
         "emcee",
         "pymc3",
         "tqdm",
+        "numpyro",
     ],
 }
 EXTRA_REQUIRE["dev"] = (

--- a/setup.py
+++ b/setup.py
@@ -182,6 +182,12 @@ else:
             include_dirs=include_dirs,
             language="c++",
         ),
+        Extension(
+            "celerite2.jax.xla_ops",
+            ["python/celerite2/jax/xla_ops.cpp"],
+            include_dirs=include_dirs,
+            language="c++",
+        ),
     ]
 
 # END PYBIND11


### PR DESCRIPTION
The XLA ops are exposed using pybind11 based on [this example](https://github.com/danieljtait/jax_xla_adventures) (see `python/celerite2/jax/xla_ops.cpp`) and then these are exposed to JAX using the primitives defined in `python/celerite2/jax/ops.py`. Because these ops are all opaque and we've only implemented the reverse mode sweep, there are some pretty ugly hacks in there. In particular, for each JAX primitive, there are two helper primitives:

1. A dummy "jvp" primitive that *only supports abstract evaluation*. This serves as an interface between the main primitive and the:
2. A "reverse" op that is only used to compute the transpose rule for the "jvp" primitive.

This is all necessary because it's not simple to write a traceable jvp op using existing ops and the performance gained by accessing the C++ directly instead of writing the op using existing primitives is *huge*.

Note that this enables `jax.jit` and `jax.grad`, but it doesn't support forward diff or higher order autodiff. Similarly, this doesn't yet support batching via `vmap`, but that's not a fundamental limitation.

closes #1 

- [x] factor
- [x] solve
- [x] norm
- [x] dot_tril
- [x] matmul
- [x] conditional_mean
- [x] Incorporate unrolling of fixed width systems