### PR TITLE
[WIP]: Alternative (and simpler) implementation of Kronecker models

### DIFF
--- a/python/celerite2/__init__.py
+++ b/python/celerite2/__init__.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
-__all__ = ["__version__", "terms", "GaussianProcess"]
-
-from . import terms
+__all__ = ["__version__", "terms", "latent", "GaussianProcess"]
+from . import latent, terms
 from .celerite2 import GaussianProcess
 from .celerite2_version import __version__
 
@@ -12,7 +11,7 @@ __email__ = "foreman.mackey@gmail.com"
 __license__ = "MIT"
 __description__ = "Fast and scalable Gaussian Processes in 1D"
 __bibtex__ = __citation__ = r"""
-@article{celerite1,
+@article{celerite2:foremanmackey17,
    author = {{Foreman-Mackey}, D. and {Agol}, E. and {Ambikasaran}, S. and
              {Angus}, R.},
     title = "{Fast and Scalable Gaussian Process Modeling with Applications to
@@ -26,7 +25,7 @@ __bibtex__ = __citation__ = r"""
    adsurl = {http://adsabs.harvard.edu/abs/2017AJ....154..220F},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-@article{celerite2,
+@article{celerite2:foremanmackey18,
    author = {{Foreman-Mackey}, D.},
     title = "{Scalable Backpropagation for Gaussian Processes using Celerite}",
   journal = {Research Notes of the American Astronomical Society},
@@ -38,5 +37,22 @@ __bibtex__ = __citation__ = r"""
       doi = {10.3847/2515-5172/aaaf6c},
    adsurl = {http://adsabs.harvard.edu/abs/2018RNAAS...2a..31F},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+@article{celerite2:gordon20,
+       author = {{Gordon}, Tyler and {Agol}, Eric and
+                 {Foreman-Mackey}, Daniel},
+        title = "{A Fast, 2D Gaussian Process Method Based on Celerite:
+                  Applications to Transiting Exoplanet Discovery and
+                  Characterization}",
+      journal = {arXiv e-prints},
+         year = 2020,
+        month = jul,
+          eid = {arXiv:2007.05799},
+        pages = {arXiv:2007.05799},
+archivePrefix = {arXiv},
+       eprint = {2007.05799},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2020arXiv200705799G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 """

--- a/python/celerite2/latent.py
+++ b/python/celerite2/latent.py
@@ -5,7 +5,7 @@ __all__ = ["apply_latent", "prepare_rectangular_data", "KronLatent"]
 import numpy as np
 
 
-def apply_latent(latent_value, *, a, U, V, P):
+def apply_latent(latent_value, *, a=None, U, V, P=None):
     latent_value = np.atleast_3d(latent_value)
 
     N, J = U.shape
@@ -19,14 +19,16 @@ def apply_latent(latent_value, *, a, U, V, P):
             f"got {latent_value.shape}"
         )
 
-    a[:] *= np.sum(latent_value ** 2, axis=(1, 2))
+    if a is not None:
+        a[:] *= np.sum(latent_value ** 2, axis=(1, 2))
     if M == 1:
         U[:] *= latent_value[:, :, 0]
         V[:] *= latent_value[:, :, 0]
     else:
         U = (U[:, :, None] * latent_value).reshape((N, -1))
         V = (V[:, :, None] * latent_value).reshape((N, -1))
-        P = np.tile(P[:, :, None], (1, 1, M)).reshape(N - 1, -1)
+        if P is not None:
+            P = np.tile(P[:, :, None], (1, 1, M)).reshape(N - 1, -1)
 
     return a, U, V, P
 

--- a/python/celerite2/latent.py
+++ b/python/celerite2/latent.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+__all__ = ["apply_latent", "prepare_rectangular_data", "KronLatent"]
+
+import numpy as np
+
+
+def apply_latent(latent_value, *, a, U, V, P):
+    latent_value = np.atleast_3d(latent_value)
+
+    N, J = U.shape
+    M = latent_value.shape[2]
+
+    valid_sizes = ((N, J, M), (N, 1, M))
+    if latent_value.shape not in valid_sizes:
+        raise ValueError(
+            "The 'latent' function returned an invalid shape; "
+            f"expected ({N}, {J}, {M}) or expected ({N}, 1, {M}), "
+            f"got {latent_value.shape}"
+        )
+
+    a[:] *= np.sum(latent_value ** 2, axis=(1, 2))
+    if M == 1:
+        U[:] *= latent_value[:, :, 0]
+        V[:] *= latent_value[:, :, 0]
+    else:
+        U = (U[:, :, None] * latent_value).reshape((N, -1))
+        V = (V[:, :, None] * latent_value).reshape((N, -1))
+        P = np.tile(P[:, :, None], (1, 1, M)).reshape(N - 1, -1)
+
+    return a, U, V, P
+
+
+def prepare_rectangular_data(N, M, t, **kwargs):
+    results = dict(
+        t=np.tile(np.asarray(t)[:, None], (1, M)).flatten(),
+        X=np.tile(np.arange(M), N),
+    )
+
+    for k, v in kwargs.items():
+        results[k] = np.ascontiguousarray(
+            np.broadcast_to(v, (N, M)), dtype=np.float64
+        ).flatten()
+
+    return results
+
+
+class KronLatent:
+    def __init__(self, *, R=None, L=None):
+        if R is not None:
+            if L is not None:
+                raise ValueError("Only one of 'R' and 'L' can be defined")
+            R = np.ascontiguousarray(np.atleast_2d(R), dtype=np.float64)
+            try:
+                self.L = np.linalg.cholesky(R)
+            except np.linalg.LinAlgError:
+                M = np.copy(R)
+                M[np.diag_indices_from(M)] += 1e-10
+                self.L = np.linalg.cholesky(M)
+        elif L is not None:
+            self.L = np.ascontiguousarray(L, dtype=np.float64)
+            if self.L.ndim == 1:
+                self.L = np.reshape(self.L, (-1, 1))
+        else:
+            raise ValueError("One of 'R' and 'L' must be defined")
+
+    def __call__(self, t, inds):
+        return self.L[inds][:, None, :]

--- a/python/celerite2/theano/celerite2.py
+++ b/python/celerite2/theano/celerite2.py
@@ -14,9 +14,13 @@ except ImportError:
     pm = None
 
 CITATIONS = (
-    ("celerite2:foremanmackey17", "celerite2:foremanmackey18"),
+    (
+        "celerite2:foremanmackey17",
+        "celerite2:foremanmackey18",
+        "celerite2:gordon20",
+    ),
     r"""
-@article{exoplanet:foremanmackey17,
+@article{celerite2:foremanmackey17,
    author = {{Foreman-Mackey}, D. and {Agol}, E. and {Ambikasaran}, S. and
              {Angus}, R.},
     title = "{Fast and Scalable Gaussian Process Modeling with Applications to
@@ -30,7 +34,7 @@ CITATIONS = (
    adsurl = {http://adsabs.harvard.edu/abs/2017AJ....154..220F},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-@article{exoplanet:foremanmackey18,
+@article{celerite2:foremanmackey18,
    author = {{Foreman-Mackey}, D.},
     title = "{Scalable Backpropagation for Gaussian Processes using Celerite}",
   journal = {Research Notes of the American Astronomical Society},
@@ -42,6 +46,23 @@ CITATIONS = (
       doi = {10.3847/2515-5172/aaaf6c},
    adsurl = {http://adsabs.harvard.edu/abs/2018RNAAS...2a..31F},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+@article{celerite2:gordon20,
+       author = {{Gordon}, Tyler and {Agol}, Eric and
+                 {Foreman-Mackey}, Daniel},
+        title = "{A Fast, 2D Gaussian Process Method Based on Celerite:
+                  Applications to Transiting Exoplanet Discovery and
+                  Characterization}",
+      journal = {arXiv e-prints},
+         year = 2020,
+        month = jul,
+          eid = {arXiv:2007.05799},
+        pages = {arXiv:2007.05799},
+archivePrefix = {arXiv},
+       eprint = {2007.05799},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2020arXiv200705799G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 """,
 )


### PR DESCRIPTION
This supersedes #6 and supports those models and many(?) others in a much simpler framework.

The idea here is that instead of using a different kernel model, we can just label each data point with a "latent" parameter. Then, for the Kron models, the `latent` parameter to the GP is a callable that returns the relevant row of the `L` matrix for each data point. The interface would be something like the following now:

```python
import celerite2
import numpy as np

t = .... # shape: (N,)
yerr = .... # shape: (N, M)
R = ... # shape: (M, M)

# Helper for Kronecker structured data:
# returns the tiled version of `t` and the band indices `X`
data = celerite2.latent.prepare_rectangular_data(N, M, t=t, yerr=yerr)

# The model
latent = celerite2.latent.KronLatent(R=R)
kernel = celerite2.terms.SHOTerm(...)
gp = celerite2.GaussianProcess(kernel, latent=latent, **data)
```