### PR TITLE
Adding a theano shim to point to pymc3 and emit deprecation warning

### DIFF
--- a/python/celerite2/theano/__init__.py
+++ b/python/celerite2/theano/__init__.py
@@ -4,7 +4,7 @@ import warnings
 
 warnings.warn(
     "The `celerite2.theano` submodule is deprecated; "
-    "use `celerite2.theano` instead",
+    "use `celerite2.pymc3` instead",
     DeprecationWarning,
 )
 

--- a/python/celerite2/theano/__init__.py
+++ b/python/celerite2/theano/__init__.py
@@ -1,0 +1,12 @@
+__all__ = ["terms", "GaussianProcess"]
+
+import warnings
+
+warnings.warn(
+    "The `celerite2.theano` submodule is deprecated; "
+    "use `celerite2.theano` instead",
+    DeprecationWarning,
+)
+
+from celerite2.pymc3.celerite2 import GaussianProcess
+from celerite2.theano import terms

--- a/python/celerite2/theano/terms.py
+++ b/python/celerite2/theano/terms.py
@@ -9,13 +9,11 @@ __all__ = [
     "SHOTerm",
     "Matern32Term",
     "RotationTerm",
-    "OriginalCeleriteTerm",
 ]
 
 from celerite2.pymc3.terms import (
     ComplexTerm,
     Matern32Term,
-    OriginalCeleriteTerm,
     RealTerm,
     RotationTerm,
     SHOTerm,

--- a/python/celerite2/theano/terms.py
+++ b/python/celerite2/theano/terms.py
@@ -1,0 +1,27 @@
+__all__ = [
+    "Term",
+    "TermSum",
+    "TermProduct",
+    "TermDiff",
+    "TermConvolution",
+    "RealTerm",
+    "ComplexTerm",
+    "SHOTerm",
+    "Matern32Term",
+    "RotationTerm",
+    "OriginalCeleriteTerm",
+]
+
+from celerite2.pymc3.terms import (
+    ComplexTerm,
+    Matern32Term,
+    OriginalCeleriteTerm,
+    RealTerm,
+    RotationTerm,
+    SHOTerm,
+    Term,
+    TermConvolution,
+    TermDiff,
+    TermProduct,
+    TermSum,
+)

--- a/python/test/pymc3/test_pymc3_celerite2.py
+++ b/python/test/pymc3/test_pymc3_celerite2.py
@@ -29,6 +29,13 @@ term_mark = pytest.mark.parametrize(
 )
 
 
+def test_theano_import_warns():
+    with pytest.deprecated_call():
+        import celerite2.theano
+
+        del celerite2.theano
+
+
 @pytest.fixture
 def data():
     np.random.seed(40582)


### PR DESCRIPTION
As noted over in #89 the renaming of the `theano` -> `pymc3` submodule is annoying. This PR adds a shim which should at least document this change.